### PR TITLE
build standalone .exe for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+dist
+*.swp

--- a/build-for-windows.bat
+++ b/build-for-windows.bat
@@ -1,0 +1,2 @@
+python.exe -m PyInstaller git-cleanup-branches.py --workpath C:\Users\davyd.mccoll\.temp_venvs\tmp\dist_cache --specpath %TEMP%\_git-cleanup-branches --name git-cleanup-branches --noconfirm --onefile
+del /S /Q /F %TEMP%\_git-cleanup-branches

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-from distutils.core import setup
-import py2exe
-
-setup(console=["git-cleanup-branches.py"])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from distutils.core import setup
+import py2exe
+
+setup(console=["git-cleanup-branches.py"])


### PR DESCRIPTION
This script is really useful -- to make it easier to use on Windows, I've added a batch file to generate a standalone .exe. Perhaps you could provide such on the releases page?

For the moment, I've added my fork and a v1.0 artifact to my scoop bucket: https://github.com/fluffynuts/scoop-bucket which provides the same experience as you've explained for non-win32 hosts (ie, put in path (which scoop does) then run `git cleanup-branches`)